### PR TITLE
Add reference to KUE docs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,7 @@ module.exports = {
     accessTokenSecret: process.env.MAGENTO_ACCESS_TOKEN_SECRET || '00y9dl4vpxgcef3gn5mntbxtylowjcc9',
   },
 
-  kue: {}, // default KUE config works on local redis instance
+  kue: {}, // default KUE config works on local redis instance. See KUE docs for non standard redis connections
 
   db: {
 /*    driver: 'mongo',


### PR DESCRIPTION
If you run Redis on a IP address instead of localhost, you'll need to modify the Kue sttings. Imho this is not clear in the configuration.