### PR TITLE
Add extendedCategoryData in category list

### DIFF
--- a/src/adapters/magento/magento2-rest-client/lib/categories.js
+++ b/src/adapters/magento/magento2-rest-client/lib/categories.js
@@ -7,6 +7,11 @@ module.exports = function (restClient) {
         return restClient.get('/categories');
     }
     
+    module.getSingle = function (categoryId) {
+        var endpointUrl = util.format('/categories/%d', categoryId);
+        return restClient.get(endpointUrl);
+    }
+    
     module.create = function (categoryAttributes) {
         return restClient.post('/categories', categoryAttributes);
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -28,6 +28,7 @@ function commandCategories(next, reject) {
 
   adapter.run({
     transaction_key: tsk,
+    extendedCategories: cli.options.extendedCategories,
     done_callback: () => {
 
       if(cli.options.removeNonExistient){
@@ -290,6 +291,12 @@ cli.option({
  */
 cli.option({
   name: 'removeNonExistient',
+  default: false,
+  type: Boolean
+});
+
+cli.option({
+  name: 'extendedCategories',
   default: false,
   type: Boolean
 });


### PR DESCRIPTION
Add additional data to category list (for example include_in_menu) with an extra API call to single Category.
Add extendedCategoryData as an option in the cli command for categories