### PR TITLE
WIP: update cms entities names

### DIFF
--- a/src/adapters/magento/cms_block.js
+++ b/src/adapters/magento/cms_block.js
@@ -10,7 +10,7 @@ class BlockAdapter extends AbstractMagentoAdapter {
     }
 
     getEntityType() {
-        return 'm2block';
+        return 'cms_block';
     }
 
     getName() {
@@ -54,7 +54,7 @@ class BlockAdapter extends AbstractMagentoAdapter {
         return new Promise((done, reject) => {
             if (item) {
                 item.id = `${this.idCounter}`;
-                item.type = 'm2block'
+                item.type = 'cms_block'
                 this.idCounter++;
             }
           

--- a/src/adapters/magento/cms_page.js
+++ b/src/adapters/magento/cms_page.js
@@ -10,7 +10,7 @@ class PageAdapter extends AbstractMagentoAdapter {
     }
 
     getEntityType() {
-        return 'm2page';
+        return 'cms_page';
     }
 
     getName() {
@@ -48,7 +48,7 @@ class PageAdapter extends AbstractMagentoAdapter {
         return new Promise((done, reject) => {
             if (item) {
                 item.id = `${this.idCounter}`;
-                item.type = 'm2page'
+                item.type = 'cms_page'
                 this.idCounter++;
             }
           

--- a/src/cli.js
+++ b/src/cli.js
@@ -61,7 +61,7 @@ const reindexReviews = (adapterName, removeNonExistent) => {
  */
 const reindexBlocks = (adapterName, removeNonExistent) => {
   return new Promise((resolve, reject) => {
-    let adapter = factory.getAdapter(adapterName, 'm2block');
+    let adapter = factory.getAdapter(adapterName, 'cms_block');
     let tsk = new Date().getTime();
 
     adapter.run({
@@ -84,7 +84,7 @@ const reindexBlocks = (adapterName, removeNonExistent) => {
  */
 const reindexPages = (adapterName, removeNonExistent) => {
   return new Promise((resolve, reject) => {
-    let adapter = factory.getAdapter(adapterName, 'm2page');
+    let adapter = factory.getAdapter(adapterName, 'cms_page');
     let tsk = new Date().getTime();
     adapter.run({
       transaction_key: tsk,


### PR DESCRIPTION
Update cms entities name, change to `cms_block` and `cms_pages` for support:
[DivanteLtd/vue-storefront-api#140](https://github.com/DivanteLtd/vue-storefront-api/pull/140)