### PR TITLE
update to snowdog/module-cms-api ver 1.3.1

### DIFF
--- a/src/adapters/magento/cms_block.js
+++ b/src/adapters/magento/cms_block.js
@@ -6,7 +6,6 @@ class BlockAdapter extends AbstractMagentoAdapter {
     constructor(config) {
         super(config);
         this.use_paging = false;
-        this.idCounter = 0;
     }
 
     getEntityType() {
@@ -53,9 +52,7 @@ class BlockAdapter extends AbstractMagentoAdapter {
         //
         return new Promise((done, reject) => {
             if (item) {
-                item.id = `${this.idCounter}`;
                 item.type = 'cms_block'
-                this.idCounter++;
             }
           
           return done(item);

--- a/src/adapters/magento/cms_page.js
+++ b/src/adapters/magento/cms_page.js
@@ -6,7 +6,6 @@ class PageAdapter extends AbstractMagentoAdapter {
     constructor(config) {
         super(config);
         this.use_paging = false;
-        this.idCounter = 0;
     }
 
     getEntityType() {
@@ -47,9 +46,7 @@ class PageAdapter extends AbstractMagentoAdapter {
 
         return new Promise((done, reject) => {
             if (item) {
-                item.id = `${this.idCounter}`;
                 item.type = 'cms_page'
-                this.idCounter++;
             }
           
           return done(item);


### PR DESCRIPTION
support for Magento 2 db ids for block and pages. 
[snowdog/module-cms-api](https://github.com/SnowdogApps/magento2-cms-api/tree/1.3.1) ver 1.3.1 required