### PR TITLE
Fix wrong type coercion for bool commandline options

### DIFF
--- a/src/adapters/magento/category.js
+++ b/src/adapters/magento/category.js
@@ -76,7 +76,7 @@ class CategoryAdapter extends AbstractMagentoAdapter {
         return done(item);
       }
       
-      if (this.extendedCategories === true) {
+      if (this.extendedCategories) {
 
         this.api.categories.getSingle(item.id).then((result) => { 
           this._addSingleCategoryData(item, result); 

--- a/src/cli.js
+++ b/src/cli.js
@@ -104,7 +104,7 @@ const reindexPages = (adapterName, removeNonExistent) => {
 const reindexCategories = (adapterName, removeNonExistent, extendedCategories) => {
   return new Promise((resolve, reject) => {
     let adapter = factory.getAdapter(adapterName, 'category');
-    let tsk = new Date().getTime();
+    let tsk = new Date().getTime();    
 
     adapter.run({
       transaction_key: tsk,
@@ -309,7 +309,7 @@ function runProductsworker(adapterName, partitions) {
 program
   .command('attributes')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
+  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
   .action(async (cmd) => {
     await reindexAttributes(cmd.adapter, cmd.removeNonExistent);
   });
@@ -317,8 +317,8 @@ program
 program
   .command('categories')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
-  .option('--extendedCategories <extendedCategories>', '', true)
+  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
+  .option('--extendedCategories [extendedCategories]', 'extended categories import', false)
   .action(async (cmd) => {
     await reindexCategories(cmd.adapter, cmd.removeNonExistent, cmd.extendedCategories);
   });
@@ -337,9 +337,9 @@ program
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
   .option('--partitions <partitions>', 'number of partitions', 1)
   .option('--partitionSize <partitionSize>', 'size of the partitions', 200)
-  .option('--initQueue <initQueue>', 'use the queue', true)
+  .option('--initQueue [initQueue]', 'use the queue', false)
   .option('--skus <skus>', 'comma delimited list of SKUs to fetch fresh informations from', '')
-  .option('--extendedCategories <extendedCategories>', '', true)
+  .option('--extendedCategories [extendedCategories]', 'extended categories import', false)
   .action((cmd) => {
     fullReindex(cmd.adapter, true, cmd.partitions, cmd.partitionSize, cmd.initQueue, cmd.skus, cmd.extendedCategories);
   });
@@ -356,9 +356,9 @@ program
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
   .option('--partitions <partitions>', 'number of partitions', 1)
   .option('--partitionSize <partitionSize>', 'size of the partitions', 200)
-  .option('--initQueue <initQueue>', 'use the queue', true)
+  .option('--initQueue [initQueue]', 'use the queue', false)
   .option('--skus <skus>', 'comma delimited list of SKUs to fetch fresh informations from', '')
-  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
+  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
   .option('--updatedAfter <updatedAfter>', 'timestamp to start the synchronization from', '')
   .action((cmd) => {
     if (cmd.updatedAfter) {
@@ -373,9 +373,9 @@ program
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
   .option('--partitions <partitions>', 'number of partitions', 1)
   .option('--partitionSize <partitionSize>', 'size of the partitions', 200)
-  .option('--initQueue <initQueue>', 'use the queue', true)
+  .option('--initQueue [initQueue]', 'use the queue', false)
   .option('--skus <skus>', 'comma delimited list of SKUs to fetch fresh informations from', '')
-  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
+  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
   .action((cmd) => {
     let indexMeta = { lastIndexDate: new Date() }
     let updatedAfter = null
@@ -408,7 +408,7 @@ program
 program
   .command('reviews')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
+  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
   .action(async (cmd) => {
     await reindexReviews(cmd.adapter, cmd.removeNonExistent);
   })
@@ -416,7 +416,7 @@ program
 program
   .command('taxrule')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
+  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
   .action(async (cmd) => {
     await reindexTaxRules(cmd.adapter, cmd.removeNonExistent);
   })
@@ -427,7 +427,7 @@ program
 program
   .command('blocks')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
+  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
   .action(async (cmd) => {
     await reindexBlocks(cmd.adapter, cmd.removeNonExistent);
   })
@@ -435,7 +435,7 @@ program
 program
   .command('pages')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
+  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
   .action(async (cmd) => {
     await reindexPages(cmd.adapter, cmd.removeNonExistent);
   })

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,6 +15,8 @@ let kue = require('kue');
 let queue = kue.createQueue(Object.assign(config.kue, { redis: config.redis }));
 
 const reindexAttributes = (adapterName, removeNonExistent) => {
+  removeNonExistent = (removeNonExistent == 'true')
+
   return new Promise((resolve, reject) => {
     let adapter = factory.getAdapter(adapterName, 'attribute');
     let tsk = new Date().getTime();
@@ -35,6 +37,8 @@ const reindexAttributes = (adapterName, removeNonExistent) => {
 }
 
 const reindexReviews = (adapterName, removeNonExistent) => {
+  removeNonExistent = (removeNonExistent == 'true')
+
   return new Promise((resolve, reject) => {
     let adapter = factory.getAdapter(adapterName, 'review');
     let tsk = new Date().getTime();
@@ -60,6 +64,8 @@ const reindexReviews = (adapterName, removeNonExistent) => {
  * Re-index cms blocks
  */
 const reindexBlocks = (adapterName, removeNonExistent) => {
+  removeNonExistent = (removeNonExistent == 'true')
+
   return new Promise((resolve, reject) => {
     let adapter = factory.getAdapter(adapterName, 'cms_block');
     let tsk = new Date().getTime();
@@ -83,6 +89,8 @@ const reindexBlocks = (adapterName, removeNonExistent) => {
  * Re-index cms pages
  */
 const reindexPages = (adapterName, removeNonExistent) => {
+  removeNonExistent = (removeNonExistent == 'true')
+
   return new Promise((resolve, reject) => {
     let adapter = factory.getAdapter(adapterName, 'cms_page');
     let tsk = new Date().getTime();
@@ -102,9 +110,12 @@ const reindexPages = (adapterName, removeNonExistent) => {
 }
 
 const reindexCategories = (adapterName, removeNonExistent, extendedCategories) => {
+  removeNonExistent = (removeNonExistent == 'true')
+  extendedCategories = (extendedCategories == 'true')
+
   return new Promise((resolve, reject) => {
     let adapter = factory.getAdapter(adapterName, 'category');
-    let tsk = new Date().getTime();    
+    let tsk = new Date().getTime();
 
     adapter.run({
       transaction_key: tsk,
@@ -123,6 +134,8 @@ const reindexCategories = (adapterName, removeNonExistent, extendedCategories) =
 }
 
 const reindexTaxRules = (adapterName, removeNonExistent) => {
+  removeNonExistent = (removeNonExistent == 'true')
+
   return new Promise((resolve, reject) => {
     let adapter = factory.getAdapter(adapterName, 'taxrule');
     let tsk = new Date().getTime();
@@ -169,6 +182,9 @@ function cleanup(adapterName, cleanupType, transactionKey) {
 }
 
 function reindexProducts(adapterName, removeNonExistent, partitions, partitionSize, initQueue, skus, updatedAfter = null) {
+  removeNonExistent = (removeNonExistent == 'true')
+  initQueue = (initQueue == true || initQueue == 'true')
+
   let adapter = factory.getAdapter(adapterName, 'product');
 
   if (updatedAfter) {
@@ -309,7 +325,7 @@ function runProductsworker(adapterName, partitions) {
 program
   .command('attributes')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
+  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
   .action(async (cmd) => {
     await reindexAttributes(cmd.adapter, cmd.removeNonExistent);
   });
@@ -317,8 +333,8 @@ program
 program
   .command('categories')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
-  .option('--extendedCategories [extendedCategories]', 'extended categories import', false)
+  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
+  .option('--extendedCategories <extendedCategories>', 'extended categories import', false)
   .action(async (cmd) => {
     await reindexCategories(cmd.adapter, cmd.removeNonExistent, cmd.extendedCategories);
   });
@@ -337,9 +353,9 @@ program
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
   .option('--partitions <partitions>', 'number of partitions', 1)
   .option('--partitionSize <partitionSize>', 'size of the partitions', 200)
-  .option('--initQueue [initQueue]', 'use the queue', false)
+  .option('--initQueue <initQueue>', 'use the queue', true)
   .option('--skus <skus>', 'comma delimited list of SKUs to fetch fresh informations from', '')
-  .option('--extendedCategories [extendedCategories]', 'extended categories import', false)
+  .option('--extendedCategories <extendedCategories>', 'extended categories import', false)
   .action((cmd) => {
     fullReindex(cmd.adapter, true, cmd.partitions, cmd.partitionSize, cmd.initQueue, cmd.skus, cmd.extendedCategories);
   });
@@ -356,9 +372,9 @@ program
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
   .option('--partitions <partitions>', 'number of partitions', 1)
   .option('--partitionSize <partitionSize>', 'size of the partitions', 200)
-  .option('--initQueue [initQueue]', 'use the queue', false)
+  .option('--initQueue <initQueue>', 'use the queue', true)
   .option('--skus <skus>', 'comma delimited list of SKUs to fetch fresh informations from', '')
-  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
+  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
   .option('--updatedAfter <updatedAfter>', 'timestamp to start the synchronization from', '')
   .action((cmd) => {
     if (cmd.updatedAfter) {
@@ -373,9 +389,9 @@ program
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
   .option('--partitions <partitions>', 'number of partitions', 1)
   .option('--partitionSize <partitionSize>', 'size of the partitions', 200)
-  .option('--initQueue [initQueue]', 'use the queue', false)
+  .option('--initQueue <initQueue>', 'use the queue', true)
   .option('--skus <skus>', 'comma delimited list of SKUs to fetch fresh informations from', '')
-  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
+  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
   .action((cmd) => {
     let indexMeta = { lastIndexDate: new Date() }
     let updatedAfter = null
@@ -408,7 +424,7 @@ program
 program
   .command('reviews')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
+  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
   .action(async (cmd) => {
     await reindexReviews(cmd.adapter, cmd.removeNonExistent);
   })
@@ -416,7 +432,7 @@ program
 program
   .command('taxrule')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
+  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
   .action(async (cmd) => {
     await reindexTaxRules(cmd.adapter, cmd.removeNonExistent);
   })
@@ -427,7 +443,7 @@ program
 program
   .command('blocks')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
+  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
   .action(async (cmd) => {
     await reindexBlocks(cmd.adapter, cmd.removeNonExistent);
   })
@@ -435,7 +451,7 @@ program
 program
   .command('pages')
   .option('--adapter <adapter>', 'name of the adapter', 'magento')
-  .option('--removeNonExistent [removeNonExistent]', 'remove non existent products', false)
+  .option('--removeNonExistent <removeNonExistent>', 'remove non existent products', false)
   .action(async (cmd) => {
     await reindexPages(cmd.adapter, cmd.removeNonExistent);
   })

--- a/src/test_categoryextended.sh
+++ b/src/test_categoryextended.sh
@@ -10,4 +10,4 @@ export MAGENTO_ACCESS_TOKEN_SECRET=7qunl3p505rubmr7u1ijt7odyialnih9
 echo 'Default store - in our case United States / en'
 export MAGENTO_URL=http://demo-magento2.vuestorefront.io/rest
 
-node --harmony cli.js categories --removeNonExistent --extendedCategories
+node --harmony cli.js categories --removeNonExistent=true --extendedCategories=true

--- a/src/test_categoryextended.sh
+++ b/src/test_categoryextended.sh
@@ -10,9 +10,4 @@ export MAGENTO_ACCESS_TOKEN_SECRET=7qunl3p505rubmr7u1ijt7odyialnih9
 echo 'Default store - in our case United States / en'
 export MAGENTO_URL=http://demo-magento2.vuestorefront.io/rest
 
-node --harmony cli.js categories --removeNonExistent=true --extendedCategories=true
-
-
-
-
-
+node --harmony cli.js categories --removeNonExistent --extendedCategories

--- a/src/test_fullreindex.sh
+++ b/src/test_fullreindex.sh
@@ -14,12 +14,8 @@ export MAGENTO_URL=http://demo-magento2.vuestorefront.io/rest
 node --harmony cli.js blocks
 node --harmony cli.js pages 
 node --harmony cli.js reviews
-node --harmony cli.js categories --removeNonExistent=true --extendedCategories=true
+node --harmony cli.js categories --removeNonExistent --extendedCategories
 node --harmony cli.js productcategories
-node --harmony cli.js attributes --removeNonExistent=true
-node --harmony cli.js taxrule --removeNonExistent=true
-node --harmony cli.js products --removeNonExistent=true --partitions=1
-
-
-
-
+node --harmony cli.js attributes --removeNonExistent
+node --harmony cli.js taxrule --removeNonExistent
+node --harmony cli.js products --initQueue --removeNonExistent --partitions=1

--- a/src/test_fullreindex.sh
+++ b/src/test_fullreindex.sh
@@ -18,4 +18,4 @@ node --harmony cli.js categories --removeNonExistent=true --extendedCategories=t
 node --harmony cli.js productcategories
 node --harmony cli.js attributes --removeNonExistent=true
 node --harmony cli.js taxrule --removeNonExistent=true
-node --harmony cli.js products --initQueue=true --removeNonExistent=true --partitions=1
+node --harmony cli.js products --removeNonExistent=true --partitions=1

--- a/src/test_fullreindex.sh
+++ b/src/test_fullreindex.sh
@@ -14,8 +14,8 @@ export MAGENTO_URL=http://demo-magento2.vuestorefront.io/rest
 node --harmony cli.js blocks
 node --harmony cli.js pages 
 node --harmony cli.js reviews
-node --harmony cli.js categories --removeNonExistent --extendedCategories
+node --harmony cli.js categories --removeNonExistent=true --extendedCategories=true
 node --harmony cli.js productcategories
-node --harmony cli.js attributes --removeNonExistent
-node --harmony cli.js taxrule --removeNonExistent
-node --harmony cli.js products --initQueue --removeNonExistent --partitions=1
+node --harmony cli.js attributes --removeNonExistent=true
+node --harmony cli.js taxrule --removeNonExistent=true
+node --harmony cli.js products --initQueue=true --removeNonExistent=true --partitions=1

--- a/src/test_multistore.sh
+++ b/src/test_multistore.sh
@@ -15,11 +15,11 @@ export INDEX_NAME=vue_storefront_catalog_de
 node --harmony cli.js blocks
 node --harmony cli.js pages 
 node --harmony cli.js reviews
-node --harmony cli.js categories --removeNonExistent
+node --harmony cli.js categories --removeNonExistent=true
 node --harmony cli.js productcategories
-node --harmony cli.js attributes --removeNonExistent
-node --harmony cli.js taxrule --removeNonExistent
-node --harmony cli.js products --initQueue --removeNonExistent --partitions=1
+node --harmony cli.js attributes --removeNonExistent=true
+node --harmony cli.js taxrule --removeNonExistent=true
+node --harmony cli.js products --initQueue=true --removeNonExistent=true --partitions=1
 
 
 echo 'Italian store - it'
@@ -29,11 +29,11 @@ export INDEX_NAME=vue_storefront_catalog_it
 node --harmony cli.js blocks
 node --harmony cli.js pages 
 node --harmony cli.js reviews
-node --harmony cli.js categories --removeNonExistent
+node --harmony cli.js categories --removeNonExistent=true
 node --harmony cli.js productcategories
-node --harmony cli.js attributes --removeNonExistent
-node --harmony cli.js taxrule --removeNonExistent
-node --harmony cli.js products --initQueue --removeNonExistent --partitions=1
+node --harmony cli.js attributes --removeNonExistent=true
+node --harmony cli.js taxrule --removeNonExistent=true
+node --harmony cli.js products --initQueue=true --removeNonExistent=true --partitions=1
 
 
 
@@ -44,8 +44,8 @@ export INDEX_NAME=vue_storefront_catalog
 node --harmony cli.js blocks
 node --harmony cli.js pages 
 node --harmony cli.js reviews
-node --harmony cli.js categories --removeNonExistent
+node --harmony cli.js categories --removeNonExistent=true
 node --harmony cli.js productcategories
-node --harmony cli.js attributes --removeNonExistent
-node --harmony cli.js taxrule --removeNonExistent
-node --harmony cli.js products --initQueue --removeNonExistent --partitions=1
+node --harmony cli.js attributes --removeNonExistent=true
+node --harmony cli.js taxrule --removeNonExistent=true
+node --harmony cli.js products --initQueue=true --removeNonExistent=true --partitions=1

--- a/src/test_multistore.sh
+++ b/src/test_multistore.sh
@@ -15,11 +15,11 @@ export INDEX_NAME=vue_storefront_catalog_de
 node --harmony cli.js blocks
 node --harmony cli.js pages 
 node --harmony cli.js reviews
-node --harmony cli.js categories --removeNonExistent=true
+node --harmony cli.js categories --removeNonExistent
 node --harmony cli.js productcategories
-node --harmony cli.js attributes --removeNonExistent=true
-node --harmony cli.js taxrule --removeNonExistent=true
-node --harmony cli.js products --removeNonExistent=true --partitions=1
+node --harmony cli.js attributes --removeNonExistent
+node --harmony cli.js taxrule --removeNonExistent
+node --harmony cli.js products --initQueue --removeNonExistent --partitions=1
 
 
 echo 'Italian store - it'
@@ -29,11 +29,11 @@ export INDEX_NAME=vue_storefront_catalog_it
 node --harmony cli.js blocks
 node --harmony cli.js pages 
 node --harmony cli.js reviews
-node --harmony cli.js categories --removeNonExistent=true
+node --harmony cli.js categories --removeNonExistent
 node --harmony cli.js productcategories
-node --harmony cli.js attributes --removeNonExistent=true
-node --harmony cli.js taxrule --removeNonExistent=true
-node --harmony cli.js products --removeNonExistent=true --partitions=1
+node --harmony cli.js attributes --removeNonExistent
+node --harmony cli.js taxrule --removeNonExistent
+node --harmony cli.js products --initQueue --removeNonExistent --partitions=1
 
 
 
@@ -44,13 +44,8 @@ export INDEX_NAME=vue_storefront_catalog
 node --harmony cli.js blocks
 node --harmony cli.js pages 
 node --harmony cli.js reviews
-node --harmony cli.js categories --removeNonExistent=true
+node --harmony cli.js categories --removeNonExistent
 node --harmony cli.js productcategories
-node --harmony cli.js attributes --removeNonExistent=true
-node --harmony cli.js taxrule --removeNonExistent=true
-node --harmony cli.js products --removeNonExistent=true --partitions=1
-
-
-
-
-
+node --harmony cli.js attributes --removeNonExistent
+node --harmony cli.js taxrule --removeNonExistent
+node --harmony cli.js products --initQueue --removeNonExistent --partitions=1

--- a/src/test_multistore.sh
+++ b/src/test_multistore.sh
@@ -19,7 +19,7 @@ node --harmony cli.js categories --removeNonExistent=true
 node --harmony cli.js productcategories
 node --harmony cli.js attributes --removeNonExistent=true
 node --harmony cli.js taxrule --removeNonExistent=true
-node --harmony cli.js products --initQueue=true --removeNonExistent=true --partitions=1
+node --harmony cli.js products --removeNonExistent=true --partitions=1
 
 
 echo 'Italian store - it'
@@ -33,7 +33,7 @@ node --harmony cli.js categories --removeNonExistent=true
 node --harmony cli.js productcategories
 node --harmony cli.js attributes --removeNonExistent=true
 node --harmony cli.js taxrule --removeNonExistent=true
-node --harmony cli.js products --initQueue=true --removeNonExistent=true --partitions=1
+node --harmony cli.js products --removeNonExistent=true --partitions=1
 
 
 
@@ -48,4 +48,4 @@ node --harmony cli.js categories --removeNonExistent=true
 node --harmony cli.js productcategories
 node --harmony cli.js attributes --removeNonExistent=true
 node --harmony cli.js taxrule --removeNonExistent=true
-node --harmony cli.js products --initQueue=true --removeNonExistent=true --partitions=1
+node --harmony cli.js products --removeNonExistent=true --partitions=1

--- a/src/test_product.sh
+++ b/src/test_product.sh
@@ -11,4 +11,4 @@ export MAGENTO_ACCESS_TOKEN_SECRET=7qunl3p505rubmr7u1ijt7odyialnih9
 echo 'Default store - in our case United States / en'
 export MAGENTO_URL=http://demo-magento2.vuestorefront.io/rest
 
-node --harmony cli.js products --initQueue --removeNonExistent --partitions=1
+node --harmony cli.js products --removeNonExistent=true --partitions=1

--- a/src/test_product.sh
+++ b/src/test_product.sh
@@ -11,9 +11,4 @@ export MAGENTO_ACCESS_TOKEN_SECRET=7qunl3p505rubmr7u1ijt7odyialnih9
 echo 'Default store - in our case United States / en'
 export MAGENTO_URL=http://demo-magento2.vuestorefront.io/rest
 
-node --harmony cli.js products --removeNonExistent=true --partitions=1
-
-
-
-
-
+node --harmony cli.js products --initQueue --removeNonExistent --partitions=1


### PR DESCRIPTION
Fix for #53. 
Correct way is to default to false for all boolean options and drop `= true` from commandline option, since this is always interpreted as a string by commander. I know this calls for a lot of adjustments in documentation. Also mage2vs.js in vue-storefront-api would need updating. I can provide a PR for that.
Other solution would be to typecast inside cli.js but that woud create overhead where it is not neccessary.