### PR TITLE
Feature/multiselect attributes

### DIFF
--- a/src/adapters/magento/product.js
+++ b/src/adapters/magento/product.js
@@ -214,17 +214,25 @@ class ProductAdapter extends AbstractMagentoAdapter {
    * @param {Object} item 
    */
   preProcessItem(item) {
+    const config = this.config
+
     for (let customAttribute of item.custom_attributes) { // map custom attributes directly to document root scope
-      item[customAttribute.attribute_code] = customAttribute.value;
+      let attributeValue = customAttribute.value;
+      let attributeCode = customAttribute.attribute_code;
+      if(config.product.multiSelectAttributes.indexOf(attributeCode) != "-1"){
+        if(attributeValue.indexOf(",") != "-1"){
+          attributeValue = attributeValue.split(",").map(Number)
+        }
+      }
+      item[attributeCode] = attributeValue;
     }
-    item.custom_attributes = null;
+    delete item.custom_attributes;
     
     return new Promise((done, reject) => {
       // TODO: add denormalization of productcategories into product categories
       // DO NOT use "productcategories" type but rather do search categories with assigned products
 
       let subSyncPromises = []
-      const config = this.config
 
       // TODO: Refactor the following to "Chain of responsibility"
       // STOCK SYNC

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,7 @@ module.exports = {
 
   product: {
     expandConfigurableFilters: ['manufacturer'],
+    multiSelectAttributes: [], //also map these attributes as 'long' type in vue-storefront-api/config/elastic.schema.product.extension.json
     synchronizeCatalogSpecialPrices: process.env.PRODUCTS_SPECIAL_PRICES || false,
     renderCatalogRegularPrices: process.env.PRODUCTS_RENDER_PRICES || false,
     excludeDisabledProducts: process.env.PRODUCTS_EXCLUDE_DISABLED || false


### PR DESCRIPTION
Convert comma separated option_ids from multiselect Magento attributes into arrays.
You can set the attributes in config.js in the product property with a newly added property:
multiSelectAttributes

In preprocessItem in the product adapter this array is looked up, if a attribute code exists in the config array and if this attribute value contains commas it gets converted into an array.

This is necessary to enable multi selection options for attribute in layered navigation