### PR TITLE
Mapping video data for product gallery

### DIFF
--- a/src/adapters/magento/product.js
+++ b/src/adapters/magento/product.js
@@ -264,12 +264,24 @@ class ProductAdapter extends AbstractMagentoAdapter {
             let media_gallery = []
             for (let mediaItem of result){
               if (!mediaItem.disabled) {
-                media_gallery.push({
+                let newMediaObj = {
                   image: mediaItem.file,
                   pos: mediaItem.position,
                   typ: mediaItem.media_type,
                   lab: mediaItem.label
-                })
+                };
+                // Separation of ifs for future extendability
+                if (mediaItem.extension_attributes) {
+                  if (mediaItem.extension_attributes.video_content) {
+                    newMediaObj.vid = {
+                      url: mediaItem.extension_attributes.video_content.video_url,
+                      title: mediaItem.extension_attributes.video_content.video_title,
+                      desc: mediaItem.extension_attributes.video_content.video_description,
+                      meta: mediaItem.extension_attributes.video_content.video_metadata
+                    }
+                  }
+                }
+                media_gallery.push(newMediaObj)
               }
             }
             item.media_gallery = media_gallery


### PR DESCRIPTION
This supports the issue at [vue-storefront#2388](https://github.com/DivanteLtd/vue-storefront/issues/2388) and PR [vue-storefront#2433](https://github.com/DivanteLtd/vue-storefront/pull/2433). It adds the video data from the product gallery (if there are any videos) to be used by vue-storefront. 