### PR TITLE
fixed incorrect page size calculation

### DIFF
--- a/src/adapters/magento/product.js
+++ b/src/adapters/magento/product.js
@@ -65,7 +65,7 @@ class ProductAdapter extends AbstractMagentoAdapter {
     this.total_count = items.total_count;
 
     if (this.use_paging) {
-      this.page_count = Math.round(this.total_count / this.page_size);
+      this.page_count = Math.ceil(this.total_count / this.page_size);
       logger.info('Page count', this.page_count)
     }
 

--- a/src/adapters/magento/review.js
+++ b/src/adapters/magento/review.js
@@ -42,7 +42,7 @@ class ReviewAdapter extends AbstractMagentoAdapter {
     }
 
     if (this.use_paging) {
-      this.page_count = this.total_count / this.page_size;
+      this.page_count = Math.ceil(this.total_count / this.page_size);
     }
 
     if (items.items) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -209,7 +209,7 @@ function reindexProducts(adapterName, removeNonExistent, partitions, partitionSi
 
       let total_count = result.total_count;
       let page_size = partitionSize;
-      let page_count = parseInt(total_count / page_size);
+      let page_count = Math.ceil(total_count / page_size);
 
       let transaction_key = new Date().getTime();
 


### PR DESCRIPTION
Using Math.ceil ensures that you don't ignore any products.

Math.round or parseInt behaviour: 160/3 -> 3 while actually there are 4 pages.