### PR TITLE
Connect to Redis with optional Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<<<<<<< HEAD
+# [Unreleased]
+### Added
+ - Added optional Redis Auth functionality. @rain2o (#42)
+ 
 ## [1.9]
 ### Added
 - New ENV variable `SEO_USE_URL_DISPATCHER` (default = true) added. When set, then the `product.url_path` and `category.url_path` are automatically populated for the UrlDispatche featu$

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ node --harmony cli.js productsworker
 ```
 
 **Please note:** We're using [kue based on Redis queue](https://github.com/Automattic/kue) which may be configured via `src/config.js` - `kue` + `redis` section.
-**Please note:** There is no authorization mechanism in place for the webapi calls. Please keep it local / private networked or add some kind of authorization as a PR to this project please :-)
+
+ **Please note:** Redis now supports auth. In order to use Redis with auth simply pass the password to the `REDIS_AUTH` env variable.
 
 
 ### Multistore setup

--- a/src/adapters/abstract.js
+++ b/src/adapters/abstract.js
@@ -19,7 +19,7 @@ class AbstractAdapter {
     if (global.cache == null) {
       this.cache = Redis.createClient(this.config.redis); // redis client
       this.cache.on('error', (err) => { // workaround for https://github.com/NodeRedis/node_redis/issues/713
-        global.cache = Redis.createClient(this.config.redis); // redis client
+        this.cache = Redis.createClient(this.config.redis); // redis client
       });
       // redis auth if provided
       if (this.config.redis.auth) {

--- a/src/adapters/abstract.js
+++ b/src/adapters/abstract.js
@@ -21,6 +21,10 @@ class AbstractAdapter {
       this.cache.on('error', (err) => { // workaround for https://github.com/NodeRedis/node_redis/issues/713
         global.cache = Redis.createClient(this.config.redis); // redis client
       });
+      // redis auth if provided
+      if (this.config.redis.auth) {
+        this.cache.auth(this.config.redis.auth);
+      }
       global.cache = this.cache;
     } else this.cache = global.cache;
 

--- a/src/config.js
+++ b/src/config.js
@@ -60,6 +60,7 @@ module.exports = {
   redis: {
     host: process.env.REDIS_HOST || '127.0.0.1',
     port: process.env.REDIS_PORT || 6379,
+    auth: process.env.REDIS_AUTH || false,
     db: process.env.REDIS_DB || 0
   },
 


### PR DESCRIPTION
Closes #42 

This PR adds the ability to use Auth with the Redis connection. To use it you just have to set the env variable `REDIS_AUTH` to the password and the config will map it.

Related to [vue-storefront-api#268](https://github.com/DivanteLtd/vue-storefront-api/pull/268).

**Note** - There is a separate commit that changes the assignment of Redis client inside the error checker for the workaround. I don't know if this was intended and I misunderstand the functionality or if it was just an oversight. It looks like it assigned the new client to `global.cache` but just a couple lines below `global.cache` gets re-assigned. If this was intentional I can undo that commit.