### PR TITLE
Elastic 7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.11] - UNRELEASED
+### Added
+ - Elastic7 support - @pkarw (#96) 
 
 ## [1.10] - 2019.07.10
 ### Added

--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ npm run dev
 
 The key command is `docker-compose up -d` which runs the ElasticSearch and Redis instances - both required by `mage2vuestorefront`
 
+### Elastic 7 Support
+
+By default, Vue Storefront API docker files and config are based on Elastic 5.6. We plan to change the default Elastic version to 7 with the 1.11 stable release. As for now, the [Elastic 7 support](https://github.com/DivanteLtd/vue-storefront-api/pull/342) is marked as **experimental**. 
+
+In order to index data to Elastic 7 please make sure you set the proper `apiVersion` in the `config.js`:
+
+```js
+  elasticsearch: {
+    apiVersion: process.env.ELASTICSEARCH_API_VERSION || '7.1'
+  },
+```
+
+or just use the env variable:
+
+```bash
+export ELASTICSEARCH_API_VERSION=7.1
+```
+
+Starting from [Elasitc 6 and 7](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html) we can have **just single** document type per single index. Vue Storefront used to have `product`, `category` ... types defined in the `vue_storefront_catalog`.
+
+From now on, we're using the separate indexes per each entity type. The convention is: `${indexName}_${entityType}`. If your' **logical index name** is `vue_storefront_catalog` then it will be mapped to the **physical indexes** of: `vue_storefront_catalog_product`, `vue_storefront_catalog_category` ...
+
 ### Initial Vue Storefront import
 
 Now, You're ready to run the importer. Please check the [config file](https://github.com/DivanteLtd/mage2vuestorefront/blob/master/src/config.js). You may setup the Magento access data and URLs by config values or ENV variables.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   esm1:
-    image: elasticsearch:2.4.6
+    image: elasticsearch:7.3.2
     container_name: esm1
     environment:
       - cluster.name=docker-cluster
@@ -19,7 +19,7 @@ services:
     networks:
       - esnet
   esm2:
-    image: elasticsearch:5.5
+    image: elasticsearch:7.3.2
     container_name: esm2
     environment:
       - cluster.name=docker-cluster

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "@elastic/elasticsearch": "^7.3.0",
     "agentkeepalive": "^3.3.0",
     "body-parser": "^1.17.1",
     "commander": "^2.18.0",
-    "elasticsearch": "^15.2.0",
     "elasticsearch-deletebyquery": "^1.6.0",
     "express": "^4.15.2",
     "jsonfile": "^4.0.0",

--- a/src/adapters/nosql/elasticsearch.js
+++ b/src/adapters/nosql/elasticsearch.js
@@ -29,6 +29,19 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
   }
 
   /**
+   * Get physical Elastic index name; since 7.x we're adding an entity name to get real index: vue_storefront_catalog_product, vue_storefront_catalog_category and so on
+   * @param {*} baseIndexName 
+   * @param {*} config 
+   */
+  getPhysicalIndexName(collectionName, config) {
+    if (parseInt(config.elasticsearch.apiVersion) >= 6) {
+      return `${config.db.indexName}_${collectionName}`
+    } else {
+      return config.db.indexName
+    }
+  }
+
+  /**
    * Close the nosql database connection - abstract to the driver
    */
   close() { // switched to global singleton
@@ -43,7 +56,7 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
   getDocuments(collectionName, queryBody) {
     return new Promise((resolve, reject) => {
       this.db.search({ // requires ES 5.5
-        index: this.config.db.indexName,
+        index: this.getPhysicalIndexName(collectionName, this.config),
         type: collectionName,
           body: queryBody
       }, function (error, response) {
@@ -66,7 +79,7 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
     const itemtbu = item;
 
     this.db.update({
-      index: this.config.db.indexName,
+      index: this.getPhysicalIndexName(collectionName, this.config),
       id: item.id,
       type: collectionName,
       body: {
@@ -90,7 +103,7 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
 
     if (transactionKey) {
       this.db.deleteByQuery({ // requires ES 5.5
-        index: this.config.db.indexName,
+        index: this.getPhysicalIndexName(collectionName, this.config),
         conflicts: 'proceed',
         type: collectionName,
          body: {
@@ -122,7 +135,7 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
     for (let doc of items) {
       requests.push({
         update: {
-          _index: this.config.db.indexName,
+          _index: this.getPhysicalIndexName(collectionName, this.config),
           _id: doc.id,
           _type: collectionName,
         }

--- a/src/adapters/nosql/elasticsearch.js
+++ b/src/adapters/nosql/elasticsearch.js
@@ -76,7 +76,7 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
       if (parseInt(this.config.elasticsearch.apiVersion) < 6)
        searchQueryBody.type  = this.getPhysicalTypeName(collectionName, this.config)
 
-      this.db.search(searchQueryBody, function (error, response) {
+      this.db.search(searchQueryBody, function (error, { body: response }) {
         if (error) reject(error);
         if (response.hits && response.hits.hits) {
           resolve(response.hits.hits.map(h => h._source))

--- a/src/adapters/nosql/elasticsearch.js
+++ b/src/adapters/nosql/elasticsearch.js
@@ -137,7 +137,6 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
 
       this.db.deleteByQuery(query, function (error, response) {
         if (error) throw new Error(error);
-        logger.info(response);
       });
     }
   }

--- a/src/adapters/nosql/elasticsearch.js
+++ b/src/adapters/nosql/elasticsearch.js
@@ -47,7 +47,6 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
    * @param {*} config 
    */
   getPhysicalTypeName(collectionName, config) {
-    console.log(parseInt(config.elasticsearch.apiVersion) );
     if (parseInt(config.elasticsearch.apiVersion) >= 6) {
       return `_doc`
     } else {
@@ -104,7 +103,7 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
       }
     }
     if (parseInt(this.config.elasticsearch.apiVersion) < 6)
-      updateRequestBody.type = this.getPhysicalTypeName(collectionName, this.config),
+      updateRequestBody.type = this.getPhysicalTypeName(collectionName, this.config)
 
     this.db.update(updateRequestBody, function (error, response) {
       if (error)
@@ -134,7 +133,7 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
         }
       };
       if (parseInt(this.config.elasticsearch.apiVersion) < 6)
-        query.type = this.getPhysicalTypeName(collectionName, this.config),
+        query.type = this.getPhysicalTypeName(collectionName, this.config)
 
       this.db.deleteByQuery(query, function (error, response) {
         if (error) throw new Error(error);
@@ -159,7 +158,7 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
         _id: doc.id,
       };
       if (parseInt(this.config.elasticsearch.apiVersion) < 6)
-        query.type = this.getPhysicalTypeName(collectionName, this.config),
+        query.type = this.getPhysicalTypeName(collectionName, this.config)
 
       requests.push({
         update: query
@@ -199,7 +198,7 @@ class ElasticsearchAdapter extends AbstractNosqlAdapter {
     if (!global.es) {
       this.db = new elasticsearch.Client({
         node: this.config.db.url,
-        log: 'error',
+        log: 'debug',
         apiVersion: this.config.elasticsearch.apiVersion,
 
         maxRetries: 10,

--- a/src/config.js
+++ b/src/config.js
@@ -61,7 +61,7 @@ module.exports = {
   },
 
   elasticsearch: {
-    apiVersion: process.env.ELASTICSEARCH_API_VERSION || '7.x'
+    apiVersion: process.env.ELASTICSEARCH_API_VERSION || '5.6'
   },
 
   redis: {

--- a/src/config.js
+++ b/src/config.js
@@ -61,7 +61,7 @@ module.exports = {
   },
 
   elasticsearch: {
-    apiVersion: process.env.ELASTICSEARCH_API_VERSION || '5.6'
+    apiVersion: process.env.ELASTICSEARCH_API_VERSION || '7.3'
   },
 
   redis: {

--- a/src/config.js
+++ b/src/config.js
@@ -61,7 +61,7 @@ module.exports = {
   },
 
   elasticsearch: {
-    apiVersion: process.env.ELASTICSEARCH_API_VERSION || '7.3'
+    apiVersion: process.env.ELASTICSEARCH_API_VERSION || '7.x'
   },
 
   redis: {


### PR DESCRIPTION
Details: https://github.com/DivanteLtd/vue-storefront/issues/1692

TODO:
- [x] support `@elastic/elasticsearch5.x `for legacy mode based on `config.elasticsearch.apiVersion`
- [x] seemingly only 840 products fro 2036 are being imported - to check why is that (mapping?)
- [x] docs
- [x] tests in the `legacy` mode